### PR TITLE
Fix 2nd & subsequent calls to “ant”

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,7 @@
+#
+# Don't directly modify this file. Instead, copy it to local.build.properties and
+# edit that.
+#
+
+project.name=markdown
 project.version=0.6

--- a/build.xml
+++ b/build.xml
@@ -1,28 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project default="xar" name="markdown">
+<project default="all" name="markdown">
     <property file="local.build.properties"/>
     <property file="build.properties"/>
-    <property name="project.app" value="markdown"/>
     <property name="build" value="./build"/>
-    <property name="server.url" value="http://demo.exist-db.org/exist/apps/public-repo/public/"/>
+    <!--<property name="server.url" value="http://demo.exist-db.org/exist/apps/public-repo/public/"/>-->
+    <condition property="git.commit" value="${git.commit}" else="">
+        <isset property="git.commit"/>
+    </condition>
+    <target name="all" depends="xar"/>
+    <target name="rebuild" depends="clean,all"/>
     <target name="clean">
-        <delete failonerror="false">
-            <fileset dir="${build}">
-                <include name="*.xar"/>
-            </fileset>
-        </delete>
+        <delete dir="${build}"/>
         <delete file="expath-pkg.xml"/>
     </target>
     <target name="xar">
+        <mkdir dir="${build}"/>
         <copy file="expath-pkg.xml.tmpl" tofile="expath-pkg.xml" filtering="true" overwrite="true">
             <filterset>
+                <filter token="project.name" value="${project.name}"/>
                 <filter token="project.version" value="${project.version}"/>
             </filterset>
         </copy>
-        <mkdir dir="${build}"/>
-        <zip basedir="." destfile="${build}/${project.app}-${project.version}.xar" excludes="${build}/*"/>
+        <zip destfile="${build}/${project.name}-${project.version}${git.commit}.xar">
+            <fileset dir=".">
+                <include name="*.*"/>
+                <include name="content/**"/>
+                <exclude name="${build}/*"/>
+                <exclude name="*.tmpl"/>
+                <exclude name="*.properties"/>
+            </fileset>
+        </zip>
     </target>
-    <target name="upload">
+    <!--<target name="upload">
         <input message="Enter password:" addproperty="server.pass" defaultvalue="">
             <handler type="secure"/>
         </input>
@@ -30,5 +39,5 @@
         <exec executable="curl">
             <arg line="-T ${build}/${xar} -u admin:${server.pass} ${server.url}/${xar}"/>
         </exec>
-    </target>
+    </target>-->
 </project>

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/markdown" abbrev="markdown" version="@project.version@" spec="1.0">
+<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/markdown" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>Markdown Parser in XQuery</title>
     <dependency processor="http://exist-db.org" semver-min="3.6.0"/>
     <dependency package="http://exist-db.org/apps/shared"/>


### PR DESCRIPTION
Before this PR, calling `ant` a 2nd time would fail with an error:

```
BUILD FAILED
/Users/joe/workspace/exist-markdown/build.xml:23: A zip file cannot include itself
```

This PR fixes the builds, and borrows from more recently updated eXist xar build files. It also comments out the upload target, since the URL referenced is no longer valid.