### PR TITLE
Fix misinterpretation of inline strong as list

### DIFF
--- a/content/markdown.xql
+++ b/content/markdown.xql
@@ -373,7 +373,7 @@ declare function markdown:table-col-class($spec as xs:string?) {
 };
 
 declare %private function markdown:list($block as xs:string, $config as map(*)) {
-    if (matches($block, "^\s*([\*\+\-]|\d\.\s+\S)")) then
+    if (matches($block, "^\s*([+\-]|\*[^*]|\d\.\s+\S)")) then
         let $analyzed := analyze-string($block, "^\s*(?:[\*\+\-]|\d\.)\s*", "ms")
         for $match in $analyzed/fn:match
         let $spaces := replace(replace($match, "^\s*\n", ""), "^(\s*?)\S.*$", "$1")


### PR DESCRIPTION
_Just a note: I closed and re-opened this PR with a separate branch on my side!_

The parser misinterpreted `**strong**` inlines (with asterisks) at line beginning as list items.
So the following markdown...

```md
* Hello
* World

Some text...

**Hello World**
```

...was parsed as...

```html
<ul>
    <li>Hello</li>
    <li>World</li>
</ul>
<p>Some text...</p>
<ul>
    <li><em>Hello World</em></li>
</ul>
```

...when instead it should actually be...

```html
<ul>
    <li>Hello</li>
    <li>World</li>
</ul>
<p>Some text...</p>
<p><strong>Hello World</strong></p>
```

This PR fixes this behavior by improving the Regular Expression used for detecting list items. It now only recognizes a line starting with `*` as a list item if the next character is not also a `*`.