### PR TITLE
Toward a fix for markdown

### DIFF
--- a/content/markdown.xql
+++ b/content/markdown.xql
@@ -134,7 +134,7 @@ declare function markdown:parse($input as xs:string?) {
 
 declare function markdown:parse($input as xs:string?, $configs as map(*)+) {
     let $config := map:merge($configs)
-	let $split := analyze-string(replace($input || "&#10;", "\t", "    "), $markdown:RE_SPLIT_BLOCKS, "sm")
+	let $split := analyze-string(replace($input || "&#10;", "\t", "    "), $markdown:RE_SPLIT_BLOCKS, "m")
     let $blocks := <wrapper>{markdown:parse-blocks($split/fn:match/fn:group[1]/text(), $config)}</wrapper>
     let $cleaned := markdown:cleanup($config, $blocks/*[1], ())
     let $output := markdown:process-inlines($config, $cleaned, $markdown:SPAN_HANDLERS, $blocks)
@@ -293,7 +293,7 @@ declare %private function markdown:heading($block as xs:string, $config as map(*
     else if (matches($block, "\n*\-\-+$")) then
         $config("heading")(2, replace($block, "^(.*)\s*\-+", "$1"))
     else if (matches($block, "^\s*#{1,6}")) then
-        let $level := replace($block, "^\s*(#+).*", "$1")
+        let $level := replace($block, "^\s*(#+).*", "$1", "m")
         return
             <markdown:heading level="{string-length($level)}">{ replace($block, "^\s*#{1,6}\s*(.*)$", "$1")}</markdown:heading>
     else

--- a/content/markdown.xql
+++ b/content/markdown.xql
@@ -180,7 +180,7 @@ declare %private function markdown:emphasis($config as map(*), $text as text(), 
 };
 
 declare function markdown:inline-html($config as map(*), $text as text(), $content as node()*) {
-    let $analyzed := analyze-string($text, "(&lt;.+?(&lt;/[^&gt;]+&gt;|&gt;/))")
+    let $analyzed := analyze-string($text, "(&lt;.+?(&lt;/[^&gt;]+&gt;|&gt;/))", "s")
     for $token in $analyzed/*
     return
         typeswitch($token)


### PR DESCRIPTION
The approach taken here was to adjust the flags for regular expressions functions. See https://www.w3.org/TR/xpath-functions-31/#flags.

My guess about the source of the problems is that https://github.com/eXist-db/exist/pull/3530 introduced subtle changes to the handling of flags.

To be confident in these fixes, we would really need to adapt the https://github.com/eXist-db/exist-markdown/blob/master/test.md file into proper unit tests. I believe there are still problems in the parsing of inline HTML. Preparing per-feature tests would help narrow that problem down and confirm that any/all covered markdown features work as expected.